### PR TITLE
大まかなバックエンド機能の完成

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -28,3 +28,6 @@ archive.zip
 
 # macOS
 .DS_Store
+
+# アップロードされたファイルはステージングされないようにする
+uploads/

--- a/back/main.py
+++ b/back/main.py
@@ -1,29 +1,34 @@
-from fastapi import FastAPI, File, UploadFile, HTTPException
-from fastapi.responses import JSONResponse
-import shutil
 import os
-from typing import List
+import shutil
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 
 # アップロードされた写真を保存するディレクトリのパス
 upload_dir = "./uploads"
 
+# 静的ファイルへのパスにアクセスすることで画像を閲覧することができるように
+app.mount("/uploads", StaticFiles(directory=upload_dir), name="uploads")
+
 # アップロードされた写真を保存する関数
-def save_uploaded_file(upload_dir: str, upload_file: UploadFile):
+def save_uploaded_file(upload_dir: str, upload_file: UploadFile) -> None:
     try:
         # ファイルを保存する
-        with open(os.path.join(upload_dir, upload_file.filename), "wb") as buffer:
-            shutil.copyfileobj(upload_file.file, buffer)
+        if upload_file.filename is not None:
+            with open(os.path.join(upload_dir, upload_file.filename), "wb") as buffer:
+                shutil.copyfileobj(fsrc=upload_file.file, fdst=buffer)
     finally:
         # ファイルを閉じる
         upload_file.file.close()
 
 # 複数のファイルを受け取るエンドポイント
-@app.post("/upload/")
-async def upload_files(files: List[UploadFile] = File(...)):
-    if not os.path.exists(upload_dir):
-        os.makedirs(upload_dir)
+@app.post(path="/")       
+async def upload_files(files: list[UploadFile] = File(default=...)) -> JSONResponse:
+    if not os.path.exists(path=upload_dir):
+        os.makedirs(name=upload_dir)
     
     # アップロードする写真の数が5枚を超える場合はエラーを返す
     max_files = 5
@@ -31,6 +36,16 @@ async def upload_files(files: List[UploadFile] = File(...)):
         raise HTTPException(status_code=400, detail="Max files limit exceeded. Max 5 files allowed.")
 
     for file in files:
-        save_uploaded_file(upload_dir, file)
+        save_uploaded_file(upload_dir=upload_dir, upload_file=file)
     return JSONResponse(status_code=201, content={"message": "Files uploaded successfully"})
     
+    
+# ファイルへのパスを配信するエンドポイント
+@app.get(path="/")
+def get_file_path() -> JSONResponse:
+    if not os.path.exists(path=upload_dir):
+        raise HTTPException(status_code=404, detail="No files uploaded yet.")
+    
+    # アップロードされた写真のパスを取得する
+    files: list[str] = os.listdir(path=upload_dir)
+    return JSONResponse(status_code=200, content={"files": files})


### PR DESCRIPTION
画像をアップロード、閲覧が可能になりました。
APIサーバを立ち上げてlocalhost:8000にUploadFileを含めてPOSTリクエストを送ることで画像をアップロードでき、
localhost:8000にGETリクエストを送ると画像のファイル名が一覧表示されます。
また、localhost:8000/uploads/ファイル名で画像にアクセスできますので、<img src = localhost:8000/uploads/ファイル名>とすると画像が表示できます。
