### PR TITLE
全画面表示にした際に、headerが隠れてしまわないように修正

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -2,7 +2,7 @@
   <!-- ぞのはここにページのレイアウトを書く -->
   <div>
     <header>
-      <div class="menu-button">&#9776;</div>
+      <div class="menu-button">&#9776;</div>      <!-- '&#9776;' ハンバーガーアイコン -->
       <h1>PixShow</h1>
       <UploadButton/>
     </header>
@@ -27,57 +27,63 @@ export default {
 </script>
 
 <style>
-      body,
-      html {
-        overflow: hidden;
-        background-color: #05294f;
-        text-align: center;
-        margin: 0;
-        padding: 0;
-      }
+body,
+html {
+  overflow: hidden;
+  background-color: #05294f;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
 
-      header {
-        background-color: #272727;
-        color: #fff;
-        text-align: center;
-        padding: 1%;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: #272727;
+  color: #fff;
+  text-align: center;
+  padding: 1%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1000;
+}
 
-      .menu-button {
-        font-size: 28px;
-        cursor: pointer;
-        margin-left: 1%;
-      }
+.menu-button {
+  font-size: 28px;
+  cursor: pointer;
+  margin-left: 1%;
+}
 
-      .upload-button {
-        background-color: #ffffff;
-        color: #000000;
-        border: none;
-        padding: 6px 9px;
-        border-radius: 5px;
-        cursor: pointer;
-        margin-right: 1%;
-      }
+.upload-button {
+  background-color: #ffffff;
+  color: #000000;
+  border: none;
+  padding: 6px 9px;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-right: 1%;
+}
 
-      .upload-button:hover {
-        background-color: #bdbdbd;
-        color: #000000;
-      }
+.upload-button:hover {
+  background-color: #bdbdbd;
+  color: #000000;
+}
 
-      .content {
-        display: flex;
-        justify-content: center; /* コンテナ要素を横方向に中央揃え */
-        align-items: center; /* コンテナ要素を垂直方向に中央揃え */
-        height: calc(100vh - 100px); /* ヘッダーを除いた部分の高さ */
-      }
+.content {
+  margin-top: 60px; /* ヘッダーの高さ */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 60px); /* 画面の高さからヘッダーの高さを引いた値 */
+}
 
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: contain;
-        object-position: center;
-      }
+img {
+  max-width: 100%;
+  max-height: calc(100% - 60px); /* 画像の高さを画面の高さからヘッダーの高さを引いた値に制限 */
+  object-fit: contain;
+  object-position: center;
+}
 </style>

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -80,10 +80,4 @@ header {
   height: calc(100vh - 60px); /* 画面の高さからヘッダーの高さを引いた値 */
 }
 
-img {
-  max-width: 100%;
-  max-height: calc(100% - 60px); /* 画像の高さを画面の高さからヘッダーの高さを引いた値に制限 */
-  object-fit: contain;
-  object-position: center;
-}
 </style>

--- a/front/src/components/ImageDisplay.vue
+++ b/front/src/components/ImageDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <transition name="slide-fade">
-      <img v-if="showImage" :src="image" alt="Server Image" :key="currentIndex">
+      <img class="display-image" v-if="showImage" :src="image" alt="Server Image" :key="currentIndex">
     </transition> 
   </div>
 </template>
@@ -58,6 +58,13 @@ onMounted(() => {
 </script>
 
 <style>
+.display-image {
+  max-width: 100%;
+  max-height: calc(100% - 60px); /* 画像の高さを画面の高さからヘッダーの高さを引いた値に制限 */
+  object-fit: contain;
+  object-position: center;
+}
+
 .slide-fade-enter-active {
   transition: opacity 0.5s ease-out, transform 0.5s ease-out;
 }

--- a/front/src/components/ImageDisplay.vue
+++ b/front/src/components/ImageDisplay.vue
@@ -1,48 +1,74 @@
 <template>
-    <div>
-      <!-- 画像を表示する -->
-      <img :src="image" alt="Server Image">
-    </div>
-  </template>
-  
-  <script setup>
-  import { ref, onMounted } from 'vue'
-  
-  const image = ref('') // 画像のURLを格納するリファレンス
-  let currentIndex = 0; // 現在の画像のインデックス
-  
-  // サーバーから画像を取得して表示する関数
-  const fetchAndDisplayImage = () => {
-    try {
-      // サーバーから画像のURLを取得するためのリクエストを送信
-      fetch('http://127.0.0.1:8000')
-        .then(response => {
-          if (!response.ok) {
-            throw new Error('Failed to fetch image');
-          }
-          // レスポンスから JSON データを取得
-          return response.json();
-        })
-        .then(data => {
-          // JSON データから次の画像の URL を取得してセット
-          const nextImageUrl = data.files[currentIndex];
-          image.value = `http://localhost:8000/uploads/${nextImageUrl}`;
-          // 次の画像のインデックスを更新する
-          currentIndex = (currentIndex + 1) % data.files.length;
-        })
-        .catch(error => {
-          console.error('Error fetching image:', error);
-        });
-    } catch (error) {
-      console.error('Error fetching image:', error);
-    }
+  <div>
+    <transition name="slide-fade">
+      <img v-if="showImage" :src="image" alt="Server Image" :key="currentIndex">
+    </transition> 
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+
+const image = ref('') // 画像のURLを格納するリファレンス
+let currentIndex = 0; // 現在の画像のインデックス
+const showImage = ref(false); // 画像を表示するかどうかのフラグ
+const interval = 5000; // 画像を切り替える間隔
+
+// サーバーから画像を取得して表示する関数
+const fetchAndDisplayImage = () => {
+  try {
+    // サーバーから画像のURLを取得するためのリクエストを送信
+    fetch('http://127.0.0.1:8000')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to fetch image');
+        }
+        // レスポンスから JSON データを取得
+        return response.json();
+      })
+      .then(data => {
+        // JSON データから次の画像の URL を取得してセット
+        const nextImageUrl = data.files[currentIndex];
+        image.value = `http://localhost:8000/uploads/${nextImageUrl}`;
+        // 次の画像のインデックスを更新する
+        currentIndex = (currentIndex + 1) % data.files.length;
+      })
+      .catch(error => {
+        console.error('Error fetching image:', error);
+      });
+  } catch (error) {
+    console.error('Error fetching image:', error);
   }
-  
-  // コンポーネントがマウントされたときに画像を取得して表示する
-  onMounted(() => {
-    fetchAndDisplayImage();
-    // 5秒ごとに次の画像を取得して表示する
-    setInterval(fetchAndDisplayImage, 5000);
-  })
-  </script>
-  
+}
+
+// 監視: imageの変更を監視し、新しい画像が読み込まれた後に古い画像を表示する
+watch(image, () => {
+  showImage.value = true;
+  setTimeout(() => {
+    showImage.value = false;
+  }, interval - 750);
+})
+
+// コンポーネントがマウントされたときに画像を取得して表示する
+onMounted(() => {
+  fetchAndDisplayImage();
+  // 8秒ごとに次の画像を取得して表示する
+  setInterval(fetchAndDisplayImage, interval);
+})
+</script>
+
+<style>
+.slide-fade-enter-active {
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.slide-fade-leave-active {
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.slide-fade-enter-from, .slide-fade-leave-to {
+  opacity: 0;
+  transform: translateX(-20px);
+}
+</style>
+


### PR DESCRIPTION
サイトを全画面表示にした際に、画像サイズが大きい際にheaderが隠れてしまうバグがあった。
そのため、画像の最大サイズを制限することにより修正した。
また、abc.vueという空のファイルが/componentsにあったため、削除した。